### PR TITLE
feat: add face swap API for web clients

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import os
+
+os.environ['OMP_NUM_THREADS'] = '1'
+
+from facefusion.api import app
+
+if __name__ == '__main__':
+        import uvicorn
+        uvicorn.run(app, host = '0.0.0.0', port = 8000)
+

--- a/facefusion/api.py
+++ b/facefusion/api.py
@@ -49,3 +49,49 @@ def swap_face(source: UploadFile = File(...), target: UploadFile = File(...)) ->
                 media_type = 'video/mp4' if output_ext == '.mp4' else 'image/jpeg'
                 return FileResponse(output_path, media_type=media_type, filename=f'swapped{output_ext}')
 
+
+@app.post('/preview')
+def preview_face(source: UploadFile = File(...), target: UploadFile = File(...), frame: int = 0) -> FileResponse:
+        with tempfile.TemporaryDirectory() as workdir:
+                source_path = os.path.join(workdir, f"source{os.path.splitext(source.filename or '')[1]}")
+                target_path = os.path.join(workdir, f"target{os.path.splitext(target.filename or '')[1]}")
+                preview_path = os.path.join(workdir, 'preview.jpg')
+
+                with open(source_path, 'wb') as source_file:
+                        source_file.write(source.file.read())
+                with open(target_path, 'wb') as target_file:
+                        target_file.write(target.file.read())
+
+                if (target.filename or '').lower().endswith(('.mp4', '.mov', '.avi', '.mkv')):
+                        frame_path = os.path.join(workdir, 'frame.jpg')
+                        ffmpeg_cmd = [
+                                'ffmpeg', '-i', target_path,
+                                '-vf', f"select='eq(n,{frame})'",
+                                '-vframes', '1', frame_path
+                        ]
+                        ffmpeg_result = subprocess.run(ffmpeg_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                        if ffmpeg_result.returncode != 0 or not os.path.exists(frame_path):
+                                raise HTTPException(status_code=500, detail='Frame extraction failed')
+                        target_frame = frame_path
+                else:
+                        target_frame = target_path
+
+                jobs_path = os.path.join(workdir, 'jobs')
+                init_jobs(jobs_path)
+
+                commands = [
+                        sys.executable,
+                        str(CLI_PATH),
+                        'headless-run',
+                        '--jobs-path', jobs_path,
+                        '--processors', 'face_swapper',
+                        '-s', source_path,
+                        '-t', target_frame,
+                        '-o', preview_path
+                ]
+                result = subprocess.run(commands, cwd=ROOT_PATH)
+                if result.returncode != 0 or not os.path.exists(preview_path):
+                        raise HTTPException(status_code=500, detail='Preview failed')
+
+                return FileResponse(preview_path, media_type='image/jpeg', filename='preview.jpg')
+

--- a/facefusion/api.py
+++ b/facefusion/api.py
@@ -1,0 +1,51 @@
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi.responses import FileResponse
+from facefusion.jobs.job_manager import init_jobs
+
+os.environ['OMP_NUM_THREADS'] = '1'
+
+app = FastAPI()
+
+ROOT_PATH = Path(__file__).resolve().parent.parent
+CLI_PATH = ROOT_PATH / 'facefusion.py'
+
+
+@app.post('/swap')
+def swap_face(source: UploadFile = File(...), target: UploadFile = File(...)) -> FileResponse:
+        with tempfile.TemporaryDirectory() as workdir:
+                source_path = os.path.join(workdir, f"source{os.path.splitext(source.filename or '')[1]}")
+                target_path = os.path.join(workdir, f"target{os.path.splitext(target.filename or '')[1]}")
+                output_ext = '.mp4' if (target.filename or '').lower().endswith('.mp4') else '.jpg'
+                output_path = os.path.join(workdir, f"output{output_ext}")
+
+                with open(source_path, 'wb') as source_file:
+                        source_file.write(source.file.read())
+                with open(target_path, 'wb') as target_file:
+                        target_file.write(target.file.read())
+
+                jobs_path = os.path.join(workdir, 'jobs')
+                init_jobs(jobs_path)
+
+                commands = [
+                        sys.executable,
+                        str(CLI_PATH),
+                        'headless-run',
+                        '--jobs-path', jobs_path,
+                        '--processors', 'face_swapper',
+                        '-s', source_path,
+                        '-t', target_path,
+                        '-o', output_path
+                ]
+                result = subprocess.run(commands, cwd=ROOT_PATH)
+                if result.returncode != 0 or not os.path.exists(output_path):
+                        raise HTTPException(status_code=500, detail='Face swap failed')
+
+                media_type = 'video/mp4' if output_ext == '.mp4' else 'image/jpeg'
+                return FileResponse(output_path, media_type=media_type, filename=f'swapped{output_ext}')
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ opencv-python==4.11.0.86
 psutil==7.0.0
 tqdm==4.67.1
 scipy==1.15.2
+fastapi==0.110.2
+uvicorn==0.30.1
+python-multipart==0.0.9

--- a/tests/test_api_face_swapper.py
+++ b/tests/test_api_face_swapper.py
@@ -1,0 +1,32 @@
+import subprocess
+
+import pytest
+from fastapi.testclient import TestClient
+
+from facefusion.api import app
+from facefusion.download import conditional_download
+from .helper import get_test_example_file, get_test_examples_directory
+
+client = TestClient(app)
+
+
+@pytest.fixture(scope = 'module', autouse = True)
+def before_all() -> None:
+        conditional_download(get_test_examples_directory(),
+        [
+                'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/source.jpg',
+                'https://github.com/facefusion/facefusion-assets/releases/download/examples-3.0.0/target-240p.mp4'
+        ])
+        subprocess.run([ 'ffmpeg', '-i', get_test_example_file('target-240p.mp4'), '-vframes', '1', get_test_example_file('target-240p.jpg') ])
+
+
+def test_swap_face() -> None:
+        with open(get_test_example_file('source.jpg'), 'rb') as source, open(get_test_example_file('target-240p.jpg'), 'rb') as target:
+                files = {
+                        'source': ('source.jpg', source, 'image/jpeg'),
+                        'target': ('target-240p.jpg', target, 'image/jpeg')
+                }
+                response = client.post('/swap', files = files)
+        assert response.status_code == 200
+        assert response.content
+

--- a/tests/test_api_face_swapper.py
+++ b/tests/test_api_face_swapper.py
@@ -30,3 +30,14 @@ def test_swap_face() -> None:
         assert response.status_code == 200
         assert response.content
 
+
+def test_preview_face() -> None:
+        with open(get_test_example_file('source.jpg'), 'rb') as source, open(get_test_example_file('target-240p.mp4'), 'rb') as target:
+                files = {
+                        'source': ('source.jpg', source, 'image/jpeg'),
+                        'target': ('target-240p.mp4', target, 'video/mp4')
+                }
+                response = client.post('/preview', params = { 'frame': 0 }, files = files)
+        assert response.status_code == 200
+        assert response.content
+


### PR DESCRIPTION
## Summary
- expose `/swap` endpoint with FastAPI to run face swap via CLI
- include runnable `api.py` server entry point
- document requirements for API and add tests

## Testing
- `pip install fastapi==0.110.2 uvicorn==0.30.1 python-multipart==0.0.9` *(failed: Tunnel connection failed: 403 Forbidden)*
- `pytest -q` *(failed: 33 errors during collection)*
- `pytest tests/test_api_face_swapper.py -q` *(failed: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a73b45efa8832cb9312642ad6a1d34